### PR TITLE
fix: add `FXLegData` to `ProcedureLeg` union

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4,7 +4,6 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "msfs-navigation-data-interface",
       "workspaces": [
         "examples/*",
         "src/js/*"
@@ -10130,7 +10129,7 @@
     },
     "src/js": {
       "name": "@navigraph/msfs-navigation-data-interface",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "license": "MIT"
     }
   }

--- a/src/js/types/ProcedureLeg/FCLeg.ts
+++ b/src/js/types/ProcedureLeg/FCLeg.ts
@@ -1,0 +1,21 @@
+import { LegType, ProcedureLegBase, TurnDirection } from "."
+import { Fix } from "../fix"
+import { Degrees, NauticalMiles } from "../math"
+
+export interface FCLegData extends ProcedureLegBase {
+  leg_type: LegType.FC
+
+  fix: Fix
+
+  recommended_navaid: Fix
+
+  turn_direction?: TurnDirection
+
+  theta: Degrees
+
+  rho: NauticalMiles
+
+  course: Degrees
+
+  length: NauticalMiles
+}

--- a/src/js/types/ProcedureLeg/PILeg.ts
+++ b/src/js/types/ProcedureLeg/PILeg.ts
@@ -1,0 +1,21 @@
+import { LegType, ProcedureLegBase, TurnDirection } from "."
+import { Fix } from "../fix"
+import { Degrees, NauticalMiles } from "../math"
+
+export interface PILegData extends ProcedureLegBase {
+  leg_type: LegType.PI
+
+  fix: Fix
+
+  recommended_navaid: Fix
+
+  turn_direction: TurnDirection
+
+  theta: Degrees
+
+  rho: NauticalMiles
+
+  course: Degrees
+
+  length: NauticalMiles
+}

--- a/src/js/types/ProcedureLeg/index.ts
+++ b/src/js/types/ProcedureLeg/index.ts
@@ -11,6 +11,7 @@ import { HALegData } from "./HALeg"
 import { HFLegData } from "./HFLeg"
 import { HMLegData } from "./HMLeg"
 import { IFLegData } from "./IFLeg"
+import { PILegData } from "./PILeg"
 import { RFLegData } from "./RFLeg"
 import { TFLegData } from "./TFLeg"
 import { VALegData } from "./VALeg"
@@ -150,7 +151,16 @@ export interface ProcedureLegBase {
 export type HXLegData = HALegData | HFLegData | HMLegData
 export type XFLegData = AFLegData | CFLegData | DFLegData | IFLegData | RFLegData | TFLegData | HXLegData
 export type FXLegData = FALegData | FCLegData | FMLegData | FDLegData
-export type ProcedureLeg = XFLegData | FXLegData | CALegData | XILegData | XDLegData | VALegData | VMLegData | XRLegData
+export type ProcedureLeg =
+  | XFLegData
+  | FXLegData
+  | CALegData
+  | XILegData
+  | XDLegData
+  | VALegData
+  | VMLegData
+  | XRLegData
+  | PILegData
 
 export * from "./AFLeg"
 export * from "./CALeg"
@@ -164,6 +174,7 @@ export * from "./HALeg"
 export * from "./HFLeg"
 export * from "./HMLeg"
 export * from "./IFLeg"
+export * from "./PILeg"
 export * from "./RFLeg"
 export * from "./TFLeg"
 export * from "./VALeg"

--- a/src/js/types/ProcedureLeg/index.ts
+++ b/src/js/types/ProcedureLeg/index.ts
@@ -4,6 +4,7 @@ import { CALegData } from "./CALeg"
 import { CFLegData } from "./CFLeg"
 import { DFLegData } from "./DFLeg"
 import { FALegData } from "./FALeg"
+import { FCLegData } from "./FCLeg"
 import { FDLegData } from "./FDLeg"
 import { FMLegData } from "./FMLeg"
 import { HALegData } from "./HALeg"
@@ -148,7 +149,7 @@ export interface ProcedureLegBase {
 
 export type HXLegData = HALegData | HFLegData | HMLegData
 export type XFLegData = AFLegData | CFLegData | DFLegData | IFLegData | RFLegData | TFLegData | HXLegData
-export type FXLegData = FALegData | FMLegData | FDLegData
+export type FXLegData = FALegData | FCLegData | FMLegData | FDLegData
 export type ProcedureLeg = XFLegData | FXLegData | CALegData | XILegData | XDLegData | VALegData | VMLegData | XRLegData
 
 export * from "./AFLeg"
@@ -156,6 +157,7 @@ export * from "./CALeg"
 export * from "./CFLeg"
 export * from "./DFLeg"
 export * from "./FALeg"
+export * from "./FCLeg"
 export * from "./FDLeg"
 export * from "./FMLeg"
 export * from "./HALeg"

--- a/src/js/types/ProcedureLeg/index.ts
+++ b/src/js/types/ProcedureLeg/index.ts
@@ -149,7 +149,7 @@ export interface ProcedureLegBase {
 export type HXLegData = HALegData | HFLegData | HMLegData
 export type XFLegData = AFLegData | CFLegData | DFLegData | IFLegData | RFLegData | TFLegData | HXLegData
 export type FXLegData = FALegData | FMLegData | FDLegData
-export type ProcedureLeg = XFLegData | CALegData | XILegData | XDLegData | VALegData | VMLegData | XRLegData
+export type ProcedureLeg = XFLegData | FXLegData | CALegData | XILegData | XDLegData | VALegData | VMLegData | XRLegData
 
 export * from "./AFLeg"
 export * from "./CALeg"


### PR DESCRIPTION
I'm currently writing an interface using your JS package and noticed that the type of `ProcedureLeg` does not include `FXLegData`.

At first I assumed that this was intentional, but I later faced issues when processing the `DEGE3S.RW16` departure from `LSZH`, which includes an `FA` leg despite transitions having a legs type of `ProcedureLeg[]`. I've also noticed this with the `GERS1H.RW34` departure, which contains an `FD` leg.

I also noticed that `FC` legs were missing from the `FXLegData` union, which came up on the `L34RY.KAIHO` approach into `RJTT`, and so were `PI` legs which came up on the `L20.HRV` approach into `KMSY`.