### PR TITLE
Download navigation data in chunks

### DIFF
--- a/example/gauge/Components/Pages/Auth/Auth.tsx
+++ b/example/gauge/Components/Pages/Auth/Auth.tsx
@@ -28,7 +28,9 @@ export class AuthPage extends DisplayComponent<AuthPageProps> {
     super(props);
 
     this.props.navigationDataInterface.onEvent(NavigraphEventType.DownloadProgress, data => {
-      this.displayMessage(`Downloaded ${data.downloaded_bytes}/${data.total_bytes} bytes`);
+      this.displayMessage(
+        `Downloaded ${data.downloaded_bytes}/${data.total_bytes} bytes (chunk ${data.current_chunk}/${data.total_chunks})`,
+      );
     });
   }
 

--- a/example/gauge/Components/Pages/Auth/Auth.tsx
+++ b/example/gauge/Components/Pages/Auth/Auth.tsx
@@ -1,6 +1,5 @@
 import { ComponentProps, DisplayComponent, FSComponent, VNode } from "@microsoft/msfs-sdk";
 import {
-  DownloadProgressPhase,
   NavigationDataStatus,
   NavigraphEventType,
   NavigraphNavigationDataInterface,
@@ -29,22 +28,7 @@ export class AuthPage extends DisplayComponent<AuthPageProps> {
     super(props);
 
     this.props.navigationDataInterface.onEvent(NavigraphEventType.DownloadProgress, data => {
-      switch (data.phase) {
-        case DownloadProgressPhase.Downloading:
-          this.displayMessage("Downloading navigation data...");
-          break;
-        case DownloadProgressPhase.Cleaning:
-          if (!data.deleted) return;
-          this.displayMessage(`Cleaning destination directory. ${data.deleted} files deleted so far`);
-          break;
-        case DownloadProgressPhase.Extracting: {
-          // Ensure non-null
-          if (!data.unzipped || !data.total_to_unzip) return;
-          const percent = Math.round((data.unzipped / data.total_to_unzip) * 100);
-          this.displayMessage(`Unzipping files... ${percent}% complete`);
-          break;
-        }
-      }
+      this.displayMessage(`Downloaded ${data.downloaded_bytes}/${data.total_bytes} bytes`);
     });
   }
 

--- a/src/ts/interface/NavigationDataInterfaceTypes.ts
+++ b/src/ts/interface/NavigationDataInterfaceTypes.ts
@@ -11,17 +11,9 @@ export enum NavigraphEventType {
   DownloadProgress = "DownloadProgress",
 }
 
-export enum DownloadProgressPhase {
-  Downloading = "Downloading",
-  Cleaning = "Cleaning",
-  Extracting = "Extracting",
-}
-
 export interface DownloadProgressData {
-  phase: DownloadProgressPhase;
-  deleted: number | null;
-  total_to_unzip: number | null;
-  unzipped: number | null;
+  total_bytes: number;
+  downloaded_bytes: number;
 }
 
 export enum NavigraphFunction {

--- a/src/ts/interface/NavigationDataInterfaceTypes.ts
+++ b/src/ts/interface/NavigationDataInterfaceTypes.ts
@@ -14,6 +14,8 @@ export enum NavigraphEventType {
 export interface DownloadProgressData {
   total_bytes: number;
   downloaded_bytes: number;
+  current_chunk: number;
+  total_chunks: number;
 }
 
 export enum NavigraphFunction {

--- a/src/wasm/Cargo.toml
+++ b/src/wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "msfs-navigation-data-interface"
-version = "1.2.0-rc1"
+version = "1.2.0-rc2"
 edition = "2021"
 
 [lib]

--- a/src/wasm/src/lib.rs
+++ b/src/wasm/src/lib.rs
@@ -24,8 +24,14 @@ const HEARTBEAT_INTERVAL_MS: u128 = 1000;
 /// The data associated with the `DownloadProgress` event
 #[derive(Serialize)]
 pub struct DownloadProgressEvent {
+    /// The total amount of bytes to download
     pub total_bytes: usize,
+    /// The amount of bytes downloaded
     pub downloaded_bytes: usize,
+    /// The chunk number (starting at 0) of the current download
+    pub current_chunk: usize,
+    /// The total number of chunks needed to download
+    pub total_chunks: usize,
 }
 
 /// The types of events that can be emitted from the interface

--- a/src/wasm/src/lib.rs
+++ b/src/wasm/src/lib.rs
@@ -21,28 +21,18 @@ mod sentry_gauge;
 /// Amount of MS between dispatches of the heartbeat commbus event
 const HEARTBEAT_INTERVAL_MS: u128 = 1000;
 
-/// The current phase of downloading
-#[derive(Serialize)]
-pub enum DownloadProgressPhase {
-    Downloading,
-    Cleaning,
-    Extracting,
-}
-
 /// The data associated with the `DownloadProgress` event
 #[derive(Serialize)]
 pub struct DownloadProgressEvent {
-    pub phase: DownloadProgressPhase,
-    pub deleted: Option<usize>,
-    pub total_to_unzip: Option<usize>,
-    pub unzipped: Option<usize>,
+    pub total_bytes: usize,
+    pub downloaded_bytes: usize,
 }
 
 /// The types of events that can be emitted from the interface
 #[derive(Serialize)]
 enum NavigraphEventType {
     Heartbeat,
-    DownloadProgress, // TODO: remove in a future version. here for backwards compatibility
+    DownloadProgress,
 }
 
 /// The structure of an event message


### PR DESCRIPTION
Resolves the issues reported here https://forum.navigraph.com/t/navdata-cant-be-updated-inibuilds-a350/18869, pertaining to requests timing out for users with a slower internet connection

Relevant devsupport thread: https://devsupport.flightsimulator.com/t/wasm-network-requests-instantly-failing/13740

https://app.clickup.com/t/2628431/SIMDEV-534