### PR TITLE
Emissive fix, 2024 wasm module removal and doc update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,7 @@ _PackageInt
 .rollup.cache
 tsconfig.tsbuildinfo
 .vs
-examples/aircraft/NavigationDataInterfaceAircraftProject.xml.user
+example/aircraft/NavigationDataInterfaceAircraftProject.xml.user
 example/aircraft/PackageSources/html_ui/Pages/VCockpit/Instruments/Navigraph/NavigationDataInterfaceSample
 example/aircraft/PackageSources/SimObjects/Airplanes/Navigraph_Navigation_Data_Interface_Aircraft/panel/msfs_navigation_data_interface.wasm
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,9 +22,8 @@ RUN cargo install --git https://github.com/navigraph/cargo-msfs
 # Cache bust arg to re-install both SDKs
 ARG CACHEBUST
 
-# Install MSFS2020 and MSFS2024 SDK
-RUN cargo-msfs install msfs2020 && \
-    cargo-msfs install msfs2024
+# Install MSFS2020 SDK
+RUN cargo-msfs install msfs2020
 
 # Needed when running in CI/CD to avoid dubious ownership errors
 RUN git config --global --add safe.directory /workspace

--- a/README.md
+++ b/README.md
@@ -87,8 +87,9 @@ The default location for navigation data is `work/NavigationData`.
 
 1. Create a `.env` file in the root of this repository, containing a `SENTRY_URL` variable. Provide your own DSN, or leave it empty.
 2. Run `bun run build:wasm` at the root of the repository (requires Docker)
-   - This will take a while to download and build the first time, but subsequent runs will be quicker
-3. The compiled WASM module will be copied to `dist/wasm`. There will be two folders - `2020` and `2024`, for each sim version
+   - This will take a while to download and build the first time, but subsequent runs will be quicker.
+   - The WASM module will be compatible for MSFS 2020 & 2024.
+3. The WASM module that is compiled in `dist/wasm/2020` folder will be copied automatically to the aircraft `panel` folder.
 
 ## Interfacing with the gauge manually
 

--- a/example/aircraft/PackageDefinitions/navigraph-aircraft-navigation-data-interface-sample.xml
+++ b/example/aircraft/PackageDefinitions/navigraph-aircraft-navigation-data-interface-sample.xml
@@ -10,6 +10,7 @@
 		<VisibleInStore>true</VisibleInStore>
 		<CanBeReferenced>true</CanBeReferenced>
 	</Flags>
+	<PackageOrderHint>CUSTOM_SIMOBJECTS</PackageOrderHint>
 	<AssetGroups>
 		<AssetGroup Name="ContentInfo">
 			<Type Version="0">Copy</Type>

--- a/example/aircraft/PackageDefinitions/navigraph-aircraft-navigation-data-interface-sample.xml
+++ b/example/aircraft/PackageDefinitions/navigraph-aircraft-navigation-data-interface-sample.xml
@@ -12,7 +12,7 @@
 	</Flags>
 	<AssetGroups>
 		<AssetGroup Name="ContentInfo">
-			<Type>Copy</Type>
+			<Type Version="0">Copy</Type>
 			<Flags>
 				<FSXCompatibility>false</FSXCompatibility>
 			</Flags>
@@ -20,7 +20,7 @@
 			<OutputDir>ContentInfo\navigraph-aircraft-navigation-data-interface-sample\</OutputDir>
 		</AssetGroup>
 		<AssetGroup Name="Data">
-			<Type>Copy</Type>
+			<Type Version="0">Copy</Type>
 			<Flags>
 				<FSXCompatibility>false</FSXCompatibility>
 			</Flags>
@@ -28,7 +28,7 @@
 			<OutputDir>Data\</OutputDir>
 		</AssetGroup>
 		<AssetGroup Name="Navigraph">
-			<Type>Copy</Type>
+			<Type Version="0">Copy</Type>
 			<Flags>
 				<FSXCompatibility>false</FSXCompatibility>
 			</Flags>
@@ -36,7 +36,7 @@
 			<OutputDir>Navigraph\</OutputDir>
 		</AssetGroup>
 		<AssetGroup Name="SimObject">
-			<Type>SimObject</Type>
+			<Type Version="1">SimObject</Type>
 			<Flags>
 				<FSXCompatibility>false</FSXCompatibility>
 			</Flags>
@@ -44,7 +44,7 @@
 			<OutputDir>SimObjects\Airplanes\Navigraph_Navigation_Data_Interface_Aircraft\</OutputDir>
 		</AssetGroup>
 		<AssetGroup Name="html_ui">
-			<Type>Copy</Type>
+			<Type Version="0">Copy</Type>
 			<Flags>
 				<FSXCompatibility>false</FSXCompatibility>
 			</Flags>
@@ -53,3 +53,4 @@
 		</AssetGroup>
 	</AssetGroups>
 </AssetPackage>
+

--- a/example/aircraft/PackageSources/SimObjects/Airplanes/Navigraph_Navigation_Data_Interface_Aircraft/model/GaugeAircraft_Interior.xml
+++ b/example/aircraft/PackageSources/SimObjects/Airplanes/Navigraph_Navigation_Data_Interface_Aircraft/model/GaugeAircraft_Interior.xml
@@ -13,5 +13,15 @@
 		<LOD minSize="1" ModelFile="GaugeAircraft_Interior_LOD04.gltf"/>
 	</LODS>
 
+	<Behaviors>
+		<Include ModelBehaviorFile="Asobo\Common.xml"/>
+
+		<Component ID="SCREEN" Node="Screens">
+			<UseTemplate Name="ASOBO_GT_Emissive_Gauge">
+				<PART_ID>SCREEN</PART_ID>
+				<EMISSIVE_CODE>1</EMISSIVE_CODE>
+			</UseTemplate>
+		</Component>
+	</Behaviors>
 
 </ModelInfo>

--- a/example/aircraft/PackageSources/SimObjects/Airplanes/Navigraph_Navigation_Data_Interface_Aircraft/texture.01/GaugeAircraft_FUSELAGE_albd_000.png.xml
+++ b/example/aircraft/PackageSources/SimObjects/Airplanes/Navigraph_Navigation_Data_Interface_Aircraft/texture.01/GaugeAircraft_FUSELAGE_albd_000.png.xml
@@ -1,0 +1,4 @@
+<BitmapConfiguration>
+	<BitmapSlot>MTL_BITMAP_DECAL0</BitmapSlot>
+</BitmapConfiguration>
+

--- a/example/aircraft/PackageSources/SimObjects/Airplanes/Navigraph_Navigation_Data_Interface_Aircraft/texture.01/GaugeAircraft_WINGS_albd_000.png.xml
+++ b/example/aircraft/PackageSources/SimObjects/Airplanes/Navigraph_Navigation_Data_Interface_Aircraft/texture.01/GaugeAircraft_WINGS_albd_000.png.xml
@@ -1,0 +1,4 @@
+<BitmapConfiguration>
+	<BitmapSlot>MTL_BITMAP_DECAL0</BitmapSlot>
+</BitmapConfiguration>
+

--- a/example/aircraft/PackageSources/SimObjects/Airplanes/Navigraph_Navigation_Data_Interface_Aircraft/texture.02/GaugeAircraft_FUSELAGE_albd_000.png.xml
+++ b/example/aircraft/PackageSources/SimObjects/Airplanes/Navigraph_Navigation_Data_Interface_Aircraft/texture.02/GaugeAircraft_FUSELAGE_albd_000.png.xml
@@ -1,0 +1,4 @@
+<BitmapConfiguration>
+	<BitmapSlot>MTL_BITMAP_DECAL0</BitmapSlot>
+</BitmapConfiguration>
+

--- a/example/aircraft/PackageSources/SimObjects/Airplanes/Navigraph_Navigation_Data_Interface_Aircraft/texture.02/GaugeAircraft_WINGS_albd_000.png.xml
+++ b/example/aircraft/PackageSources/SimObjects/Airplanes/Navigraph_Navigation_Data_Interface_Aircraft/texture.02/GaugeAircraft_WINGS_albd_000.png.xml
@@ -1,0 +1,4 @@
+<BitmapConfiguration>
+	<BitmapSlot>MTL_BITMAP_DECAL0</BitmapSlot>
+</BitmapConfiguration>
+

--- a/example/aircraft/PackageSources/SimObjects/Airplanes/Navigraph_Navigation_Data_Interface_Aircraft/texture.base/Pilot_ARMS_albd.png.xml
+++ b/example/aircraft/PackageSources/SimObjects/Airplanes/Navigraph_Navigation_Data_Interface_Aircraft/texture.base/Pilot_ARMS_albd.png.xml
@@ -1,0 +1,4 @@
+<BitmapConfiguration>
+	<BitmapSlot>MTL_BITMAP_DECAL0</BitmapSlot>
+</BitmapConfiguration>
+

--- a/example/aircraft/PackageSources/SimObjects/Airplanes/Navigraph_Navigation_Data_Interface_Aircraft/texture.base/Pilot_ARMS_comp.png.xml
+++ b/example/aircraft/PackageSources/SimObjects/Airplanes/Navigraph_Navigation_Data_Interface_Aircraft/texture.base/Pilot_ARMS_comp.png.xml
@@ -1,0 +1,5 @@
+<BitmapConfiguration>
+	<BitmapSlot>MTL_BITMAP_METAL_ROUGH_AO</BitmapSlot>
+	<ForceNoAlpha>true</ForceNoAlpha>
+</BitmapConfiguration>
+

--- a/example/aircraft/PackageSources/SimObjects/Airplanes/Navigraph_Navigation_Data_Interface_Aircraft/texture.base/Pilot_ARMS_norm.png.xml
+++ b/example/aircraft/PackageSources/SimObjects/Airplanes/Navigraph_Navigation_Data_Interface_Aircraft/texture.base/Pilot_ARMS_norm.png.xml
@@ -1,0 +1,4 @@
+<BitmapConfiguration>
+	<BitmapSlot>MTL_BITMAP_NORMAL</BitmapSlot>
+</BitmapConfiguration>
+

--- a/example/aircraft/PackageSources/SimObjects/Airplanes/Navigraph_Navigation_Data_Interface_Aircraft/texture.base/Pilot_CAP_albd.png.xml
+++ b/example/aircraft/PackageSources/SimObjects/Airplanes/Navigraph_Navigation_Data_Interface_Aircraft/texture.base/Pilot_CAP_albd.png.xml
@@ -1,0 +1,4 @@
+<BitmapConfiguration>
+	<BitmapSlot>MTL_BITMAP_DECAL0</BitmapSlot>
+</BitmapConfiguration>
+

--- a/example/aircraft/PackageSources/SimObjects/Airplanes/Navigraph_Navigation_Data_Interface_Aircraft/texture.base/Pilot_CAP_comp.png.xml
+++ b/example/aircraft/PackageSources/SimObjects/Airplanes/Navigraph_Navigation_Data_Interface_Aircraft/texture.base/Pilot_CAP_comp.png.xml
@@ -1,0 +1,5 @@
+<BitmapConfiguration>
+	<BitmapSlot>MTL_BITMAP_METAL_ROUGH_AO</BitmapSlot>
+	<ForceNoAlpha>true</ForceNoAlpha>
+</BitmapConfiguration>
+

--- a/example/aircraft/PackageSources/SimObjects/Airplanes/Navigraph_Navigation_Data_Interface_Aircraft/texture.base/Pilot_CAP_norm.png.xml
+++ b/example/aircraft/PackageSources/SimObjects/Airplanes/Navigraph_Navigation_Data_Interface_Aircraft/texture.base/Pilot_CAP_norm.png.xml
@@ -1,0 +1,4 @@
+<BitmapConfiguration>
+	<BitmapSlot>MTL_BITMAP_NORMAL</BitmapSlot>
+</BitmapConfiguration>
+

--- a/example/aircraft/PackageSources/SimObjects/Airplanes/Navigraph_Navigation_Data_Interface_Aircraft/texture.base/Pilot_EYES_albd.png.xml
+++ b/example/aircraft/PackageSources/SimObjects/Airplanes/Navigraph_Navigation_Data_Interface_Aircraft/texture.base/Pilot_EYES_albd.png.xml
@@ -1,0 +1,4 @@
+<BitmapConfiguration>
+	<BitmapSlot>MTL_BITMAP_DECAL0</BitmapSlot>
+</BitmapConfiguration>
+

--- a/example/aircraft/PackageSources/SimObjects/Airplanes/Navigraph_Navigation_Data_Interface_Aircraft/texture.base/Pilot_EYES_comp.png.xml
+++ b/example/aircraft/PackageSources/SimObjects/Airplanes/Navigraph_Navigation_Data_Interface_Aircraft/texture.base/Pilot_EYES_comp.png.xml
@@ -1,0 +1,5 @@
+<BitmapConfiguration>
+	<BitmapSlot>MTL_BITMAP_METAL_ROUGH_AO</BitmapSlot>
+	<ForceNoAlpha>true</ForceNoAlpha>
+</BitmapConfiguration>
+

--- a/example/aircraft/PackageSources/SimObjects/Airplanes/Navigraph_Navigation_Data_Interface_Aircraft/texture.base/Pilot_EYES_norm.png.xml
+++ b/example/aircraft/PackageSources/SimObjects/Airplanes/Navigraph_Navigation_Data_Interface_Aircraft/texture.base/Pilot_EYES_norm.png.xml
@@ -1,0 +1,4 @@
+<BitmapConfiguration>
+	<BitmapSlot>MTL_BITMAP_NORMAL</BitmapSlot>
+</BitmapConfiguration>
+

--- a/example/aircraft/PackageSources/SimObjects/Airplanes/Navigraph_Navigation_Data_Interface_Aircraft/texture.base/Pilot_HAIRCARDS_albd.png.xml
+++ b/example/aircraft/PackageSources/SimObjects/Airplanes/Navigraph_Navigation_Data_Interface_Aircraft/texture.base/Pilot_HAIRCARDS_albd.png.xml
@@ -1,0 +1,4 @@
+<BitmapConfiguration>
+	<BitmapSlot>MTL_BITMAP_DECAL0</BitmapSlot>
+</BitmapConfiguration>
+

--- a/example/aircraft/PackageSources/SimObjects/Airplanes/Navigraph_Navigation_Data_Interface_Aircraft/texture.base/Pilot_HAIRCARDS_comp.png.xml
+++ b/example/aircraft/PackageSources/SimObjects/Airplanes/Navigraph_Navigation_Data_Interface_Aircraft/texture.base/Pilot_HAIRCARDS_comp.png.xml
@@ -1,0 +1,5 @@
+<BitmapConfiguration>
+	<BitmapSlot>MTL_BITMAP_METAL_ROUGH_AO</BitmapSlot>
+	<ForceNoAlpha>true</ForceNoAlpha>
+</BitmapConfiguration>
+

--- a/example/aircraft/PackageSources/SimObjects/Airplanes/Navigraph_Navigation_Data_Interface_Aircraft/texture.base/Pilot_HAIRCARDS_norm.png.xml
+++ b/example/aircraft/PackageSources/SimObjects/Airplanes/Navigraph_Navigation_Data_Interface_Aircraft/texture.base/Pilot_HAIRCARDS_norm.png.xml
@@ -1,0 +1,4 @@
+<BitmapConfiguration>
+	<BitmapSlot>MTL_BITMAP_NORMAL</BitmapSlot>
+</BitmapConfiguration>
+

--- a/example/aircraft/PackageSources/SimObjects/Airplanes/Navigraph_Navigation_Data_Interface_Aircraft/texture.base/Pilot_HEADSET_albd.png.xml
+++ b/example/aircraft/PackageSources/SimObjects/Airplanes/Navigraph_Navigation_Data_Interface_Aircraft/texture.base/Pilot_HEADSET_albd.png.xml
@@ -1,0 +1,4 @@
+<BitmapConfiguration>
+	<BitmapSlot>MTL_BITMAP_DECAL0</BitmapSlot>
+</BitmapConfiguration>
+

--- a/example/aircraft/PackageSources/SimObjects/Airplanes/Navigraph_Navigation_Data_Interface_Aircraft/texture.base/Pilot_HEADSET_comp.png.xml
+++ b/example/aircraft/PackageSources/SimObjects/Airplanes/Navigraph_Navigation_Data_Interface_Aircraft/texture.base/Pilot_HEADSET_comp.png.xml
@@ -1,0 +1,5 @@
+<BitmapConfiguration>
+	<BitmapSlot>MTL_BITMAP_METAL_ROUGH_AO</BitmapSlot>
+	<ForceNoAlpha>true</ForceNoAlpha>
+</BitmapConfiguration>
+

--- a/example/aircraft/PackageSources/SimObjects/Airplanes/Navigraph_Navigation_Data_Interface_Aircraft/texture.base/Pilot_HEADSET_norm.png.xml
+++ b/example/aircraft/PackageSources/SimObjects/Airplanes/Navigraph_Navigation_Data_Interface_Aircraft/texture.base/Pilot_HEADSET_norm.png.xml
@@ -1,0 +1,4 @@
+<BitmapConfiguration>
+	<BitmapSlot>MTL_BITMAP_NORMAL</BitmapSlot>
+</BitmapConfiguration>
+

--- a/example/aircraft/PackageSources/SimObjects/Airplanes/Navigraph_Navigation_Data_Interface_Aircraft/texture.base/Pilot_HEAD_albd.png.xml
+++ b/example/aircraft/PackageSources/SimObjects/Airplanes/Navigraph_Navigation_Data_Interface_Aircraft/texture.base/Pilot_HEAD_albd.png.xml
@@ -1,0 +1,4 @@
+<BitmapConfiguration>
+	<BitmapSlot>MTL_BITMAP_DECAL0</BitmapSlot>
+</BitmapConfiguration>
+

--- a/example/aircraft/PackageSources/SimObjects/Airplanes/Navigraph_Navigation_Data_Interface_Aircraft/texture.base/Pilot_HEAD_comp.png.xml
+++ b/example/aircraft/PackageSources/SimObjects/Airplanes/Navigraph_Navigation_Data_Interface_Aircraft/texture.base/Pilot_HEAD_comp.png.xml
@@ -1,0 +1,5 @@
+<BitmapConfiguration>
+	<BitmapSlot>MTL_BITMAP_METAL_ROUGH_AO</BitmapSlot>
+	<ForceNoAlpha>true</ForceNoAlpha>
+</BitmapConfiguration>
+

--- a/example/aircraft/PackageSources/SimObjects/Airplanes/Navigraph_Navigation_Data_Interface_Aircraft/texture.base/Pilot_HEAD_norm.png.xml
+++ b/example/aircraft/PackageSources/SimObjects/Airplanes/Navigraph_Navigation_Data_Interface_Aircraft/texture.base/Pilot_HEAD_norm.png.xml
@@ -1,0 +1,4 @@
+<BitmapConfiguration>
+	<BitmapSlot>MTL_BITMAP_NORMAL</BitmapSlot>
+</BitmapConfiguration>
+

--- a/example/aircraft/PackageSources/SimObjects/Airplanes/Navigraph_Navigation_Data_Interface_Aircraft/texture.base/Pilot_JACKET_albd.png.xml
+++ b/example/aircraft/PackageSources/SimObjects/Airplanes/Navigraph_Navigation_Data_Interface_Aircraft/texture.base/Pilot_JACKET_albd.png.xml
@@ -1,0 +1,4 @@
+<BitmapConfiguration>
+	<BitmapSlot>MTL_BITMAP_DECAL0</BitmapSlot>
+</BitmapConfiguration>
+

--- a/example/aircraft/PackageSources/SimObjects/Airplanes/Navigraph_Navigation_Data_Interface_Aircraft/texture.base/Pilot_JACKET_comp.png.xml
+++ b/example/aircraft/PackageSources/SimObjects/Airplanes/Navigraph_Navigation_Data_Interface_Aircraft/texture.base/Pilot_JACKET_comp.png.xml
@@ -1,0 +1,5 @@
+<BitmapConfiguration>
+	<BitmapSlot>MTL_BITMAP_METAL_ROUGH_AO</BitmapSlot>
+	<ForceNoAlpha>true</ForceNoAlpha>
+</BitmapConfiguration>
+

--- a/example/aircraft/PackageSources/SimObjects/Airplanes/Navigraph_Navigation_Data_Interface_Aircraft/texture.base/Pilot_JACKET_norm.png.xml
+++ b/example/aircraft/PackageSources/SimObjects/Airplanes/Navigraph_Navigation_Data_Interface_Aircraft/texture.base/Pilot_JACKET_norm.png.xml
@@ -1,0 +1,4 @@
+<BitmapConfiguration>
+	<BitmapSlot>MTL_BITMAP_NORMAL</BitmapSlot>
+</BitmapConfiguration>
+

--- a/example/aircraft/PackageSources/SimObjects/Airplanes/Navigraph_Navigation_Data_Interface_Aircraft/texture.base/Pilot_PANTS_albd.png.xml
+++ b/example/aircraft/PackageSources/SimObjects/Airplanes/Navigraph_Navigation_Data_Interface_Aircraft/texture.base/Pilot_PANTS_albd.png.xml
@@ -1,0 +1,4 @@
+<BitmapConfiguration>
+	<BitmapSlot>MTL_BITMAP_DECAL0</BitmapSlot>
+</BitmapConfiguration>
+

--- a/example/aircraft/PackageSources/SimObjects/Airplanes/Navigraph_Navigation_Data_Interface_Aircraft/texture.base/Pilot_PANTS_comp.png.xml
+++ b/example/aircraft/PackageSources/SimObjects/Airplanes/Navigraph_Navigation_Data_Interface_Aircraft/texture.base/Pilot_PANTS_comp.png.xml
@@ -1,0 +1,5 @@
+<BitmapConfiguration>
+	<BitmapSlot>MTL_BITMAP_METAL_ROUGH_AO</BitmapSlot>
+	<ForceNoAlpha>true</ForceNoAlpha>
+</BitmapConfiguration>
+

--- a/example/aircraft/PackageSources/SimObjects/Airplanes/Navigraph_Navigation_Data_Interface_Aircraft/texture.base/Pilot_PANTS_norm.png.xml
+++ b/example/aircraft/PackageSources/SimObjects/Airplanes/Navigraph_Navigation_Data_Interface_Aircraft/texture.base/Pilot_PANTS_norm.png.xml
@@ -1,0 +1,4 @@
+<BitmapConfiguration>
+	<BitmapSlot>MTL_BITMAP_NORMAL</BitmapSlot>
+</BitmapConfiguration>
+

--- a/example/aircraft/PackageSources/SimObjects/Airplanes/Navigraph_Navigation_Data_Interface_Aircraft/texture/GaugeAircraft_COCKPIT_albd.png.xml
+++ b/example/aircraft/PackageSources/SimObjects/Airplanes/Navigraph_Navigation_Data_Interface_Aircraft/texture/GaugeAircraft_COCKPIT_albd.png.xml
@@ -1,0 +1,4 @@
+<BitmapConfiguration>
+	<BitmapSlot>MTL_BITMAP_DECAL0</BitmapSlot>
+</BitmapConfiguration>
+

--- a/example/aircraft/PackageSources/SimObjects/Airplanes/Navigraph_Navigation_Data_Interface_Aircraft/texture/GaugeAircraft_COCKPIT_comp.png.xml
+++ b/example/aircraft/PackageSources/SimObjects/Airplanes/Navigraph_Navigation_Data_Interface_Aircraft/texture/GaugeAircraft_COCKPIT_comp.png.xml
@@ -1,0 +1,5 @@
+<BitmapConfiguration>
+	<BitmapSlot>MTL_BITMAP_METAL_ROUGH_AO</BitmapSlot>
+	<ForceNoAlpha>true</ForceNoAlpha>
+</BitmapConfiguration>
+

--- a/example/aircraft/PackageSources/SimObjects/Airplanes/Navigraph_Navigation_Data_Interface_Aircraft/texture/GaugeAircraft_COCKPIT_norm.png.xml
+++ b/example/aircraft/PackageSources/SimObjects/Airplanes/Navigraph_Navigation_Data_Interface_Aircraft/texture/GaugeAircraft_COCKPIT_norm.png.xml
@@ -1,0 +1,4 @@
+<BitmapConfiguration>
+	<BitmapSlot>MTL_BITMAP_NORMAL</BitmapSlot>
+</BitmapConfiguration>
+

--- a/example/aircraft/PackageSources/SimObjects/Airplanes/Navigraph_Navigation_Data_Interface_Aircraft/texture/GaugeAircraft_FUSELAGE_albd_000.png.xml
+++ b/example/aircraft/PackageSources/SimObjects/Airplanes/Navigraph_Navigation_Data_Interface_Aircraft/texture/GaugeAircraft_FUSELAGE_albd_000.png.xml
@@ -1,0 +1,4 @@
+<BitmapConfiguration>
+	<BitmapSlot>MTL_BITMAP_DECAL0</BitmapSlot>
+</BitmapConfiguration>
+

--- a/example/aircraft/PackageSources/SimObjects/Airplanes/Navigraph_Navigation_Data_Interface_Aircraft/texture/GaugeAircraft_FUSELAGE_comp.png.xml
+++ b/example/aircraft/PackageSources/SimObjects/Airplanes/Navigraph_Navigation_Data_Interface_Aircraft/texture/GaugeAircraft_FUSELAGE_comp.png.xml
@@ -1,0 +1,5 @@
+<BitmapConfiguration>
+	<BitmapSlot>MTL_BITMAP_METAL_ROUGH_AO</BitmapSlot>
+	<ForceNoAlpha>true</ForceNoAlpha>
+</BitmapConfiguration>
+

--- a/example/aircraft/PackageSources/SimObjects/Airplanes/Navigraph_Navigation_Data_Interface_Aircraft/texture/GaugeAircraft_FUSELAGE_norm.png.xml
+++ b/example/aircraft/PackageSources/SimObjects/Airplanes/Navigraph_Navigation_Data_Interface_Aircraft/texture/GaugeAircraft_FUSELAGE_norm.png.xml
@@ -1,0 +1,4 @@
+<BitmapConfiguration>
+	<BitmapSlot>MTL_BITMAP_NORMAL</BitmapSlot>
+</BitmapConfiguration>
+

--- a/example/aircraft/PackageSources/SimObjects/Airplanes/Navigraph_Navigation_Data_Interface_Aircraft/texture/GaugeAircraft_GLASS_norm.png.xml
+++ b/example/aircraft/PackageSources/SimObjects/Airplanes/Navigraph_Navigation_Data_Interface_Aircraft/texture/GaugeAircraft_GLASS_norm.png.xml
@@ -1,0 +1,4 @@
+<BitmapConfiguration>
+	<BitmapSlot>MTL_BITMAP_NORMAL</BitmapSlot>
+</BitmapConfiguration>
+

--- a/example/aircraft/PackageSources/SimObjects/Airplanes/Navigraph_Navigation_Data_Interface_Aircraft/texture/GaugeAircraft_LANDING_albd.png.xml
+++ b/example/aircraft/PackageSources/SimObjects/Airplanes/Navigraph_Navigation_Data_Interface_Aircraft/texture/GaugeAircraft_LANDING_albd.png.xml
@@ -1,0 +1,4 @@
+<BitmapConfiguration>
+	<BitmapSlot>MTL_BITMAP_DECAL0</BitmapSlot>
+</BitmapConfiguration>
+

--- a/example/aircraft/PackageSources/SimObjects/Airplanes/Navigraph_Navigation_Data_Interface_Aircraft/texture/GaugeAircraft_LANDING_comp.png.xml
+++ b/example/aircraft/PackageSources/SimObjects/Airplanes/Navigraph_Navigation_Data_Interface_Aircraft/texture/GaugeAircraft_LANDING_comp.png.xml
@@ -1,0 +1,5 @@
+<BitmapConfiguration>
+	<BitmapSlot>MTL_BITMAP_METAL_ROUGH_AO</BitmapSlot>
+	<ForceNoAlpha>true</ForceNoAlpha>
+</BitmapConfiguration>
+

--- a/example/aircraft/PackageSources/SimObjects/Airplanes/Navigraph_Navigation_Data_Interface_Aircraft/texture/GaugeAircraft_LANDING_norm.png.xml
+++ b/example/aircraft/PackageSources/SimObjects/Airplanes/Navigraph_Navigation_Data_Interface_Aircraft/texture/GaugeAircraft_LANDING_norm.png.xml
@@ -1,0 +1,4 @@
+<BitmapConfiguration>
+	<BitmapSlot>MTL_BITMAP_NORMAL</BitmapSlot>
+</BitmapConfiguration>
+

--- a/example/aircraft/PackageSources/SimObjects/Airplanes/Navigraph_Navigation_Data_Interface_Aircraft/texture/GaugeAircraft_LIGHTS_albd.png.xml
+++ b/example/aircraft/PackageSources/SimObjects/Airplanes/Navigraph_Navigation_Data_Interface_Aircraft/texture/GaugeAircraft_LIGHTS_albd.png.xml
@@ -1,0 +1,4 @@
+<BitmapConfiguration>
+	<BitmapSlot>MTL_BITMAP_DECAL0</BitmapSlot>
+</BitmapConfiguration>
+

--- a/example/aircraft/PackageSources/SimObjects/Airplanes/Navigraph_Navigation_Data_Interface_Aircraft/texture/GaugeAircraft_LIGHTS_comp.png.xml
+++ b/example/aircraft/PackageSources/SimObjects/Airplanes/Navigraph_Navigation_Data_Interface_Aircraft/texture/GaugeAircraft_LIGHTS_comp.png.xml
@@ -1,0 +1,5 @@
+<BitmapConfiguration>
+	<BitmapSlot>MTL_BITMAP_METAL_ROUGH_AO</BitmapSlot>
+	<ForceNoAlpha>true</ForceNoAlpha>
+</BitmapConfiguration>
+

--- a/example/aircraft/PackageSources/SimObjects/Airplanes/Navigraph_Navigation_Data_Interface_Aircraft/texture/GaugeAircraft_LIGHTS_emis.png.xml
+++ b/example/aircraft/PackageSources/SimObjects/Airplanes/Navigraph_Navigation_Data_Interface_Aircraft/texture/GaugeAircraft_LIGHTS_emis.png.xml
@@ -1,0 +1,4 @@
+<BitmapConfiguration>
+	<BitmapSlot>MTL_BITMAP_EMISSIVE</BitmapSlot>
+</BitmapConfiguration>
+

--- a/example/aircraft/PackageSources/SimObjects/Airplanes/Navigraph_Navigation_Data_Interface_Aircraft/texture/GaugeAircraft_LIGHTS_norm.png.xml
+++ b/example/aircraft/PackageSources/SimObjects/Airplanes/Navigraph_Navigation_Data_Interface_Aircraft/texture/GaugeAircraft_LIGHTS_norm.png.xml
@@ -1,0 +1,4 @@
+<BitmapConfiguration>
+	<BitmapSlot>MTL_BITMAP_NORMAL</BitmapSlot>
+</BitmapConfiguration>
+

--- a/example/aircraft/PackageSources/SimObjects/Airplanes/Navigraph_Navigation_Data_Interface_Aircraft/texture/GaugeAircraft_PROP_albd.png.xml
+++ b/example/aircraft/PackageSources/SimObjects/Airplanes/Navigraph_Navigation_Data_Interface_Aircraft/texture/GaugeAircraft_PROP_albd.png.xml
@@ -1,0 +1,4 @@
+<BitmapConfiguration>
+	<BitmapSlot>MTL_BITMAP_DECAL0</BitmapSlot>
+</BitmapConfiguration>
+

--- a/example/aircraft/PackageSources/SimObjects/Airplanes/Navigraph_Navigation_Data_Interface_Aircraft/texture/GaugeAircraft_PROP_comp.png.xml
+++ b/example/aircraft/PackageSources/SimObjects/Airplanes/Navigraph_Navigation_Data_Interface_Aircraft/texture/GaugeAircraft_PROP_comp.png.xml
@@ -1,0 +1,5 @@
+<BitmapConfiguration>
+	<BitmapSlot>MTL_BITMAP_METAL_ROUGH_AO</BitmapSlot>
+	<ForceNoAlpha>true</ForceNoAlpha>
+</BitmapConfiguration>
+

--- a/example/aircraft/PackageSources/SimObjects/Airplanes/Navigraph_Navigation_Data_Interface_Aircraft/texture/GaugeAircraft_PROP_norm.png.xml
+++ b/example/aircraft/PackageSources/SimObjects/Airplanes/Navigraph_Navigation_Data_Interface_Aircraft/texture/GaugeAircraft_PROP_norm.png.xml
@@ -1,0 +1,4 @@
+<BitmapConfiguration>
+	<BitmapSlot>MTL_BITMAP_NORMAL</BitmapSlot>
+</BitmapConfiguration>
+

--- a/example/aircraft/PackageSources/SimObjects/Airplanes/Navigraph_Navigation_Data_Interface_Aircraft/texture/GaugeAircraft_WINGS_albd_000.png.xml
+++ b/example/aircraft/PackageSources/SimObjects/Airplanes/Navigraph_Navigation_Data_Interface_Aircraft/texture/GaugeAircraft_WINGS_albd_000.png.xml
@@ -1,0 +1,4 @@
+<BitmapConfiguration>
+	<BitmapSlot>MTL_BITMAP_DECAL0</BitmapSlot>
+</BitmapConfiguration>
+

--- a/example/aircraft/PackageSources/SimObjects/Airplanes/Navigraph_Navigation_Data_Interface_Aircraft/texture/GaugeAircraft_WINGS_comp.png.xml
+++ b/example/aircraft/PackageSources/SimObjects/Airplanes/Navigraph_Navigation_Data_Interface_Aircraft/texture/GaugeAircraft_WINGS_comp.png.xml
@@ -1,0 +1,5 @@
+<BitmapConfiguration>
+	<BitmapSlot>MTL_BITMAP_METAL_ROUGH_AO</BitmapSlot>
+	<ForceNoAlpha>true</ForceNoAlpha>
+</BitmapConfiguration>
+

--- a/example/aircraft/PackageSources/SimObjects/Airplanes/Navigraph_Navigation_Data_Interface_Aircraft/texture/GaugeAircraft_WINGS_norm.png.xml
+++ b/example/aircraft/PackageSources/SimObjects/Airplanes/Navigraph_Navigation_Data_Interface_Aircraft/texture/GaugeAircraft_WINGS_norm.png.xml
@@ -1,0 +1,4 @@
+<BitmapConfiguration>
+	<BitmapSlot>MTL_BITMAP_NORMAL</BitmapSlot>
+</BitmapConfiguration>
+

--- a/package.json
+++ b/package.json
@@ -8,8 +8,6 @@
     "lint": "bun run --filter \"*\" lint",
     "typecheck": "bun run --filter \"*\" typecheck",
     "build:wasm": "bun ./scripts/cargo-msfs.ts",
-    "build:wasm:2020": "bun ./scripts/cargo-msfs.ts --version 2020",
-    "build:wasm:2024": "bun ./scripts/cargo-msfs.ts --version 2024",
     "package": "bestzip wasm.zip dist/wasm/*"
   },
   "devDependencies": {


### PR DESCRIPTION
**Package fixes**
- Fixed the glasscockpit material being white

**Build fixes:**
- Removed the 2024 WASM module build for clarity because the 2020 version works for both MSFS 2020 & MSFS 2024
- Updated doc accordingly

**Package config fixes:**
- Asset Groups now have version number
- Added texture xml config for texture files
- [PackageOrderHint](https://docs.flightsimulator.com/msfs2024/html/8_SDK_Tools/Package_Tool/Package_Tool_XML_Properties.htm?rhhlterm=packageorderhint&rhsearch=packageOrderHint#:~:text=are%20listed%20below.-,%3CPackageOrderHint%3E,-This%20is%20used) has been set to `CUSTOM_SIMOBJECTS`

https://app.clickup.com/t/2628431/SIMDEV-550
https://app.clickup.com/t/2628431/SIMDEV-549