### PR TITLE
Ensure consistent cargo-msfs version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ RUN wget https://apt.llvm.org/llvm.sh && \
 RUN rustup target install wasm32-wasip1
 
 # Install cargo-msfs
-RUN cargo install --git https://github.com/navigraph/cargo-msfs
+RUN cargo install --git https://github.com/navigraph/cargo-msfs --tag v1.1.0 --locked
 
 # Cache bust arg to re-install both SDKs
 ARG CACHEBUST


### PR DESCRIPTION
This PR ensures that the same version of cargo-msfs is pulled each time, by explicitly specifying a tag.

The cargo-msfs repository now also includes a lockfile, so dependencies should resolve to the same version every time. To ensure this is the case, the `--locked` flag was added to the cargo install command.