### PR TITLE
Fix typo in `CommunicationType` enum

### DIFF
--- a/src/wasm/src/database/types/enums.rs
+++ b/src/wasm/src/database/types/enums.rs
@@ -285,7 +285,7 @@ pub enum CommunicationType {
     GroundCommOutlet,
     #[serde(rename = "GND")]
     GroundControl,
-    #[serde(rename = "GET")]
+    #[serde(rename = "GTE")]
     GateControl,
     #[serde(rename = "HEL")]
     HelicopterFrequency,


### PR DESCRIPTION
This PR fixes #32.

From ARINC 424-18:

```
ACC Area Control Center
ACP Airlift Command Post
AIR Air to Air
APP Approach Control
ARR Arrival Control
ASO Automatic Surface Observing System (ASOS)
ATI Automatic Terminal Info Service (ATIS)
AWI Airport Weather Information Broadcast (AWIB)
AWO Automatic Weather Observing Service (AWOS)
AWS Aerodrome Weather Information Services (AWIS)
CLD Clearance Delivery
CPT Clearance, Pre-Taxi
CTA Control Area (Terminal)
CTL Control
DEP Departure Control
DIR Director (Approach Control Radar)
EFS Enroute Flight Advisory Service (EFAS)
EMR Emergency
FSS Flight Service Station
GCO Ground Comm Outlet
GND Ground Control
GTE Gate Control
HEL Helicopter Frequency
INF Information
MIL Military Frequency
MUL Multicom
OPS Operations
PAL Pilot Activated Lighting (Note 1)
RDO Radio
RDR Radar
RFS Remote Flight Service Station (RFSS)
RMP Ramp/Taxi Control
RSA Airport Radar Service Area (ARSA)
TCA Terminal Control Area (TCA)
TMA Terminal Control Area (TMA)
TML Terminal
TRS Terminal Radar Service Area (TRSA)
TWE Transcriber Weather Broadcast (TWEB)
TWR Tower, Air Traffic Control
UAC Upper Area Control
UNI Unicom
VOL Volmet
```