### PR TITLE
Pull LLVM toolchain from Debian registry

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,33 @@
 FROM rust:1.90
 
-# Install needed packages and clean up
-RUN apt update && \
-    apt install -y --no-install-recommends lsb-release wget gnupg gcc-multilib git && \
-    rm -rf /var/lib/apt/lists/*
+# Install base needed packages
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends lsb-release wget gnupg gcc-multilib git
 
-# Install clang and clean up
-RUN wget https://apt.llvm.org/llvm.sh && \
-    chmod +x llvm.sh && \
-    ./llvm.sh 17 && \
+# Install llvm-toolchain-17
+RUN apt-get install -y --no-install-recommends \
+    clang-17 \
+    clangd-17 \
+    clang-format-17 \
+    clang-tidy-17 \
+    clang-tools-17 \
+    llvm-17-dev \
+    llvm-17-tools \
+    lld-17 \
+    lldb-17 \
+    liblldb-17-dev \
+    libomp-17-dev \
+    libc++-17-dev \
+    libc++abi-17-dev \
+    libunwind-17-dev \
+    libclang-common-17-dev \
+    libclang-17-dev \
+    libclang-cpp17-dev && \
     ln -s $(which clang-17) /usr/bin/clang && \
-    ln -s $(which llvm-ar-17) /usr/bin/llvm-ar && \
-    rm llvm.sh
+    ln -s $(which llvm-ar-17) /usr/bin/llvm-ar
+
+# Remove apt index
+RUN rm -rf /var/lib/apt/lists/*
 
 # Install rust target
 RUN rustup target install wasm32-wasip1


### PR DESCRIPTION
Fixes fresh docker image builds, since LLVM 17 is no longer hosted on the LLVM registry